### PR TITLE
Allow modifying storageKey at a later stage

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -88,7 +88,7 @@ const Theme: React.FC<ThemeProviderProps> = ({
         // Unsupported
       }
     },
-    [forcedTheme]
+    [forcedTheme, storageKey]
   )
 
   const handleMediaQuery = useCallback(


### PR DESCRIPTION
We have a situation where we need to have separately controlled embeds(using next-themes), present on the same website. The best way that I could think of to solve it was to use different `storageKey` for all of them(prefixed with their namespaces). 

But on changing `storageKey`, the chosen theme isn't correctly stored in updated `storageKey`, it still uses the initial value
